### PR TITLE
Correct URL in link to Mosaic demo in _includes/features.html 

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -54,7 +54,7 @@
                         <h3 class="sub-title">Mobile friendly</h3>
                         <p>
                           The generated website can be viewed on any device - including videos.
-                          Have a look for yourself at the <a href="/demo/themes/mosaic" target="_blank">demo site</a>.
+                          Have a look for yourself at the <a href="/demos/themes/mosaic" target="_blank">demo site</a>.
                         </p>
                     </div><!--//content-->
                 </div><!--//item-->


### PR DESCRIPTION
- The link to the demos site under the "Mobile friendly" section at: https://thumbsup.github.io/ returns an HTTP 404 
- The link points to: /demo/themes/mosaic rather than /demos/themes/mosaic
-  The link was corrected in: _includes/features.html 